### PR TITLE
Complete missing Config documentations

### DIFF
--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -180,10 +180,34 @@ type Button = {
   
   // ios-only
   style: 'plain' | 'default';
-  systemItem: 'done' | 'cancel' | 'edit' | 'save' | 'add' | 'flexibleSpace' | 'compose' | 'reply' | 'action' | 'organize' | 'bookmarks' | 'search' | 'refresh' | 'stop' | 'camera' | 'trash' | 'play' | 'pause' | 'rewind' | 'fastForward' | 'undo' | 'redo' | 'pageCurl';
+  systemItem: SystemItem;
 
   // android-only
 };
+
+type SystemItem = 'done' 
+  | 'cancel' 
+  | 'edit' 
+  | 'save' 
+  | 'add' 
+  | 'flexibleSpace' 
+  | 'compose' 
+  | 'reply' 
+  | 'action' 
+  | 'organize' 
+  | 'bookmarks' 
+  | 'search' 
+  | 'refresh' 
+  | 'stop' 
+  | 'camera' 
+  | 'trash' 
+  | 'play' 
+  | 'pause' 
+  | 'rewind' 
+  | 'fastForward' 
+  | 'undo' 
+  | 'redo' 
+  | 'pageCurl'
 
 type NavigatorConfigProps = {
 
@@ -196,6 +220,9 @@ type NavigatorConfigProps = {
   rightTitle: string;
   rightImage: Image;
   rightButtons: Array<Button>;
+  leftTitle: string;
+  leftImage: Image;
+  leftButtons: Array<Button>;
   screenColor: Color;
   hidden: boolean;
   backgroundColor: Color; 
@@ -215,7 +242,6 @@ type NavigatorConfigProps = {
   navIcon: Image;
   logo: Image;
   textAlign: 'left' | 'center' | 'right';
-  leftButtons: Array<Button>;
   
   // ios-only
   prompt: string;
@@ -226,6 +252,8 @@ type NavigatorConfigProps = {
   isToolbarHidden: boolean;
   backIndicatorTransitionMaskImage: Image;
   translucent: boolean;
+  rightSystemItem: SystemItem;
+  leftSystemItem: SystemItem;
   
   // android-only
   statusBarColor: Color;

--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -220,8 +220,6 @@ type NavigatorConfigProps = {
   rightTitle: string;
   rightImage: Image;
   rightButtons: Array<Button>;
-  leftTitle: string;
-  leftImage: Image;
   leftButtons: Array<Button>;
   screenColor: Color;
   hidden: boolean;
@@ -237,6 +235,8 @@ type NavigatorConfigProps = {
   titleFontSize: number;
   subtitleFontName: string;
   subtitleFontSize: number;
+  leftTitle: string;
+  leftImage: Image;
   
   // android-only-but-should-share
   navIcon: Image;


### PR DESCRIPTION
_The same PR from main repo_

Adding documentation for left buttons on iOS. the `leftTitle` and `leftImage` props were put in `ios-only-but-should-share` since I haven't confirmed whether they work on Android or not.